### PR TITLE
Use API key for login if specified

### DIFF
--- a/scripts/bx_login.sh
+++ b/scripts/bx_login.sh
@@ -15,7 +15,13 @@ fi
 echo "Deploy pods"
 
 echo "bx login -a $CF_TARGET_URL"
-bx login -a "$CF_TARGET_URL" -u "$BLUEMIX_USER" -p "$BLUEMIX_PASSWORD" -c "$BLUEMIX_ACCOUNT" -o "$CF_ORG" -s "$CF_SPACE"
+
+if [ -z "$API_KEY"]; then
+  bx login -a "$CF_TARGET_URL" -u "$BLUEMIX_USER" -p "$BLUEMIX_PASSWORD" -c "$BLUEMIX_ACCOUNT" -o "$CF_ORG" -s "$CF_SPACE"
+else
+  bx login -a "$CF_TARGET_URL" --apikey "$API_KEY" -o "$CF_ORG" -s "$CF_SPACE"
+fi
+
 if [ $? -ne 0 ]; then
   echo "Failed to authenticate to Bluemix"
   exit 1


### PR DESCRIPTION
For users with a federated id (mostly IBMers IMO), there is a recommendation in the clusters documentation to generate and use an API key from https://iam.ng.bluemix.net/demo and use this for bx login. Adding as a dark feature, could be supported with more detail in README. API key is equivalent to user, password, and account.