### PR TITLE
Update metrics Job with the correct format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/IBM/Scalable-WordPress-deployment-on-Kubernetes.svg?branch=master)](https://travis-ci.org/IBM/Scalable-WordPress-deployment-on-Kubernetes)
+![Bluemix Deployments](https://metrics-tracker.mybluemix.net/stats/8201eec1bc017860952416f1cc5666ce/badge.svg)
 
 *Read this in other languages: [한국어](README-ko.md).*
 
@@ -36,7 +37,7 @@ This scenario provides instructions for the following tasks:
 ## Deploy to Bluemix
 If you want to deploy the wordpress directly to Bluemix, click on 'Deploy to Bluemix' button below to create a Bluemix DevOps service toolchain and pipeline for deploying the WordPress sample, else jump to [Steps](##steps)
 
-[![Create Toolchain](https://github.com/IBM/container-journey-template/blob/master/images/button.png)](https://console.ng.bluemix.net/devops/setup/deploy/)
+[![Create Toolchain](https://metrics-tracker.mybluemix.net/stats/8201eec1bc017860952416f1cc5666ce/button.svg)](https://console.ng.bluemix.net/devops/setup/deploy/)
 
 Please follow the [Toolchain instructions](https://github.com/IBM/container-journey-template/blob/master/Toolchain_Instructions_new.md) to complete your toolchain and pipeline.
 

--- a/wordpress-deployment.yaml
+++ b/wordpress-deployment.yaml
@@ -69,20 +69,21 @@ spec:
 ---
 apiVersion: batch/v1
 kind: Job
-metadata: {name: Scalable-WordPress-deployment-on-Kubernetes-metrics}
+metadata: {name: scalable-wordpress-deployment-on-kubernetes-metrics}
 spec:
   template:
-    metadata: {name: Scalable-WordPress-deployment-on-Kubernetes-metrics}
+    metadata: {name: scalable-wordpress-deployment-on-kubernetes-metrics}
     spec:
       containers:
         - env:
-            - {name: config, value: '{"repository_id": "Scalable-Wordpress-
-                  deployment-on-Kubernetes", "target_runtimes": ["Kubernetes
-                  Cluster"], "event_id": "web", "event_organizer": "dev-
-                  journeys"}'}
+            - {name: config, value: '{"event_id": "web",
+                "repository_id": "Scalable-WordPress-deployment-on-Kubernetes",
+                "target_services": ["Compose for MySQL"],
+                "target_runtimes": ["Kubernetes Cluster"],
+                "event_organizer": "dev-journeys"}'}
+            - {name: language, value: ''}
           image: journeycode/kubernetes:latest
-          imagePullPolicy: Always
-          name: Scalable-WordPress-deployment-on-Kubernetes-metrics
+          name: scalable-wordpress-deployment-on-kubernetes-metrics
           resources:
             limits: {cpu: 100m}
-          restartPolicy: Never
+      restartPolicy: Never


### PR DESCRIPTION
Sorry I misread the metrics job in #29. We should always generate the metrics job using the build.py file in https://github.com/IBM/metrics-collector-client-kubernetes/blob/master/build.py . This way we can format the metrics job correctly and avoid capitalizing the job name and extra spaces/new lines within string variables.

This PR will do the following:
- Update metrics Job with the correct format.
- Add deploy to IBM Cloud Badges