### PR TITLE
Modify script for kubernetes test on bluemix

### DIFF
--- a/tests/test-kubernetes.sh
+++ b/tests/test-kubernetes.sh
@@ -31,6 +31,10 @@ kubectl_config() {
 kubectl_deploy() {
     kubeclt_clean
 
+    echo "Modifying yaml files to ignore storage-class"
+    sed -i '$!N;/PersistentVolumeClaim.*\n.*metadata/a \ \ annotations: \n\ \ \ \ volume.beta.kubernetes.io/storage-class: ""' ../mysql-deployment.yaml
+    sed -i '$!N;/PersistentVolumeClaim.*\n.*metadata/a \ \ annotations: \n\ \ \ \ volume.beta.kubernetes.io/storage-class: ""' ../wordpress-deployment.yaml
+
     echo "Running scripts/quickstart.sh"
     "$(dirname "$0")"/../scripts/quickstart.sh
 


### PR DESCRIPTION
The previous script is relying on Dynamic provisioning for volumes. The provisioning may take a while. This change makes the test script modify the yaml files to not use any storage-class and will default to user-made local volumes.