### PR TITLE
Configure bx cli to disable version check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,10 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s ht
 chmod 0755 kubectl
 sudo mv kubectl /usr/local/bin
 
+echo "Configuring bx to disable version check"
+bx config --check-version=false
+echo "Checking bx version"
+bx --version
 echo "Install the Bluemix container-service plugin"
 bx plugin install container-service -r Bluemix
 


### PR DESCRIPTION
This commit modifies the install.sh script for bluemix.
bx will not be checking for updates anymore as this is where Travis fails because it's waiting for an input.
bx will stick to the version it downloads.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>