### PR TITLE
Remove sudo and dist tags from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 python: 2.7
 cache: pip
-sudo: required
 
 notifications:
   slack:


### PR DESCRIPTION
Remove 'sudo: required' and 'dist: trusty' from the .travis.yml
file.  Both are depricated.

Fixes #53 